### PR TITLE
More robust migrations

### DIFF
--- a/migrations/20170224170351_initial.js
+++ b/migrations/20170224170351_initial.js
@@ -1,34 +1,26 @@
-
 exports.up = function(knex) {
-  return Promise.all([knex.raw(`
-    CREATE TABLE IF NOT EXISTS "transaction"
-    (
-      credit INT NOT NULL,
-      delta INT NOT NULL,
-      description TEXT NOT NULL,
-      id UUID PRIMARY KEY NOT NULL,
-      time TIMESTAMP NOT NULL,
-      username TEXT NOT NULL
-    );
-    `
-  ), knex.raw(`
-    CREATE TABLE IF NOT EXISTS "user"
-    (
-      credit INT NOT NULL,
-      debt_allowed BOOL NOT NULL,
-      debt_hard_limit INT,
-      lastchanged TIMESTAMP NOT NULL,
-      name TEXT NOT NULL PRIMARY KEY,
-      pincode TEXT,
-      token TEXT
-    );
-    `
-  )]);
+  return knex.schema
+   .createTable('transaction', function (table) {
+       table.integer('credit').notNullable();
+       table.integer('delta').notNullable();
+       table.string('description').notNullable();
+       table.uuid('id').primary().notNullable();
+       table.timestamp('time').notNullable();
+       table.string('username').notNullable();
+    })
+    .createTable('user', function (table) {
+       table.integer('credit').notNullable();
+       table.boolean('debt_allowed').notNullable();
+       table.integer('debt_hard_limit');
+       table.timestamp('lastchanged').notNullable();
+       table.string('name').primary().notNullable();
+       table.string('pincode');
+       table.string('token');
+    });
 };
 
 exports.down = function(knex) {
-  return Promise.all([
-    knex.raw('DROP TABLE IF EXISTS "transaction"'),
-    knex.raw('DROP TABLE IF EXISTS "user"'),
-  ]);
+  return knex.schema
+   .dropTable('transaction')
+   .dropTable('user');
 };

--- a/migrations/20170401203816_userId.js
+++ b/migrations/20170401203816_userId.js
@@ -1,49 +1,52 @@
 exports.up = async function(knex) {
-  // we need to add a column at the front
-  // -> do the copy&delete-dance
-  await knex.raw(
-    `
-    CREATE TABLE IF NOT EXISTS "user_new"
-    (
-      id integer primary key AUTOINCREMENT,
-      credit INT NOT NULL,
-      debt_allowed BOOL NOT NULL,
-      debt_hard_limit INT,
-      lastchanged TIMESTAMP NOT NULL,
-      name TEXT NOT NULL UNIQUE ,
-      pincode TEXT,
-      token TEXT
-    );
-    `
-  );
-  await knex.raw('insert into user_new select ROWID as id, credit, debt_allowed, debt_hard_limit, lastchanged, name, pincode, token from user;');
-  await knex.raw('drop table user;');
-  await knex.raw('alter table user_new rename to user;');
+  // sqlite does not support alter column
+  // => create new table and rename
+  await knex.schema
+    .createTable('user_new', function (table) {
+       table.increments('id').primary();
+       table.integer('credit').notNullable();
+       table.boolean('debt_allowed').notNullable();
+       table.integer('debt_hard_limit');
+       table.timestamp('lastchanged').notNullable();
+       table.string('name').unique().notNullable();
+       table.string('pincode');
+       table.string('token');
+    });
+
+  // TODO: test statement against all supported SQL servers
+  await knex.raw(`
+            INSERT INTO user_new (credit, debt_allowed, debt_hard_limit, lastchanged, name, pincode, token)
+            SELECT credit, debt_allowed, debt_hard_limit, lastchanged, name, pincode, token
+            FROM user
+  `);
+
+  await knex.schema
+    .dropTable('user')
+    .renameTable('user_new', 'user')
+    .createTable('transaction_new', function (table) {
+       table.increments('id').primary();
+       table.integer('credit').notNullable();
+       table.integer('delta').notNullable();
+       table.string('description').notNullable();
+       table.timestamp('time').notNullable();
+       table.integer('user_id').notNullable(); //TODO: does this work in postgres?
+
+       table.foreign('user_id').references('id').inTable('user');
+    });
 
 
-  await knex.raw(
+  await knex.raw(//TODO: does " work on every database? which escaping-character does?
     `
-    CREATE TABLE IF NOT EXISTS "transaction_new"
-    (
-      id integer PRIMARY KEY AUTOINCREMENT,
-      credit INT NOT NULL,
-      delta INT NOT NULL,
-      description TEXT NOT NULL,
-      time TIMESTAMP NOT NULL,
-      user_id integer not null references user(id) on delete cascade
-    );
-    `
-  );
-  await knex.raw(
-    `
-    INSERT INTO "transaction_new"
-    SELECT "transaction".ROWID as id, "transaction".credit, delta, description, time, user.id as user_id
+    INSERT INTO transaction_new (credit, delta, description, time, user_id)
+    SELECT "transaction".credit, delta, description, time, user.id as user_id
     FROM "transaction"
     JOIN user on user.name = "transaction".username;
     `
   );
-  await knex.raw('drop table "transaction";');
-  await knex.raw('alter table "transaction_new" rename to "transaction";');
+  
+  await knex.schema
+    .dropTable('transaction')
+    .renameTable('transaction_new', 'transaction')
 };
 
 exports.down = function(knex) {};

--- a/migrations/20170924144841_products.js
+++ b/migrations/20170924144841_products.js
@@ -1,17 +1,13 @@
 exports.up = async function(knex) {
-  await knex.raw(
-    `
-      CREATE TABLE IF NOT EXISTS "products"
-      (
-        id integer primary key AUTOINCREMENT,
-        name TEXT NOT NULL UNIQUE,
-        price INT NOT NULL,
-        category TEXT NOT NULL,
-        ean TEXT NOT NULL,
-        image_path TEXT
-      );
-    `
-  );
+  return knex.schema
+   .createTable('products', function (table) {
+       table.increments('id').primary();
+       table.string('name').unique().notNullable();
+       table.integer('price').notNullable();
+       table.string('category').notNullable();
+       table.string('ean').notNullable();
+       table.string('image_path');
+    });
 };
 
 exports.down = function(knex) {};

--- a/migrations/20190626054910_userMailAndAva.js
+++ b/migrations/20190626054910_userMailAndAva.js
@@ -1,24 +1,6 @@
 exports.up = async function(knex) {
-  await knex.raw('alter table user rename to user_tmp;');
-  await knex.raw(
-    `
-    CREATE TABLE IF NOT EXISTS "user"
-    (
-      id integer primary key AUTOINCREMENT,
-      credit INT NOT NULL,
-      debt_allowed BOOL NOT NULL,
-      debt_hard_limit INT,
-      lastchanged TIMESTAMP NOT NULL,
-      name TEXT NOT NULL UNIQUE ,
-      pincode TEXT,
-      token TEXT,
-      avatar TEXT,
-      email TEXT
-    );
-    `
-  );
-  await knex.raw('insert into user select *, null, null from user_tmp;');
-  await knex.raw('drop table user_tmp;');
+  await knex.raw('ALTER TABLE user ADD COLUMN avatar TEXT;');
+  await knex.raw('ALTER TABLE user ADD COLUMN email TEXT;');
 };
 
 exports.down = function(knex) {};

--- a/migrations/20190626054910_userMailAndAva.js
+++ b/migrations/20190626054910_userMailAndAva.js
@@ -1,6 +1,9 @@
 exports.up = async function(knex) {
-  await knex.raw('ALTER TABLE user ADD COLUMN avatar TEXT;');
-  await knex.raw('ALTER TABLE user ADD COLUMN email TEXT;');
+ return knex.schema
+   .alterTable('user', function(table) {
+       table.string('avatar');
+       table.string('email');
+   });
 };
 
 exports.down = function(knex) {};


### PR DESCRIPTION
I took at look at the migrations and did the following changes:
 - do not use SELECT *, list all columns to be more robust against unexplected
   columns

 - use ALTER TABLE instead of CREATE, INSERT, DROP when possible because this
   is a metadata-only operation in sqlite which does not copy the data

 - when doing CREATE, INSERT, DROP use CREATE, INSERT, DROP, RENAME instead of
   RENAME, CREATE, INSERT, DROP as recommended in
   https://www.sqlite.org/lang_altertable.html to avoid breaking foreign keys
   constraints.

This commit references issue #217 (Rewrite of the migrations).